### PR TITLE
Add optional scope normalization

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "passport-snapchat",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Snapchat (OAuth 2.0) authorization strategy for Passport.",
   "keywords": [
     "passport",

--- a/src/strategy.ts
+++ b/src/strategy.ts
@@ -81,6 +81,14 @@ interface SnapchatStrategyOptions {
   scopeSeparator?: string;
   /**
    * @optional
+   * Determines whether Snapchat's scope strings are normalized according to Snapchat's
+   * convention of prepending the scope URL prefix to the scope string.
+   *
+   * @default true
+   */
+  normalizeScope?: boolean;
+  /**
+   * @optional
    *
    * URL used to obtain an access token from Snapchat
    *
@@ -254,7 +262,7 @@ function getGraphFieldForNormalizedFieldName(field: string): string {
 /**
  * @hidden
  */
-function normalizeScope(scope: string): string {
+function applyScopeNormalization(scope: string): string {
   return scope.startsWith('https:')
     ? scope
     : config.OAUTH_SCOPE_URL_PREFIX + scope;
@@ -273,6 +281,8 @@ function normalizeOptions(
       ? scopesStringOrArray.split(scopeSeparator)
       : scopesStringOrArray;
   const profileFields = options.profileFields || [];
+  const shouldNormalizeScope =
+    options.normalizeScope !== undefined ? options.normalizeScope : true;
   return {
     ...options,
     authorizationURL: options.authorizationURL || config.SNAP_ACCOUNTS_AUTH_URL,
@@ -280,7 +290,9 @@ function normalizeOptions(
       .map(getGraphFieldForNormalizedFieldName)
       .filter(Boolean),
     profileURL: options.profileURL || `${config.SNAP_KIT_API_URL}/me`,
-    scope: scopes.map(normalizeScope).filter(Boolean),
+    scope: shouldNormalizeScope
+      ? scopes.map(applyScopeNormalization).filter(Boolean)
+      : scopes,
     scopeSeparator,
     tokenURL: options.tokenURL || config.SNAP_ACCOUNTS_TOKEN_URL,
   };

--- a/test/strategy.spec.ts
+++ b/test/strategy.spec.ts
@@ -25,7 +25,22 @@ describe('Strategy', function() {
       expect(strategy._scope[0]).to.equal(config.OAUTH_SCOPE_URL_PREFIX + 'user.display_name');
       expect(strategy._scope[1]).to.equal(config.OAUTH_SCOPE_URL_PREFIX + 'user.bitmoji.avatar');
     });
-  })
+  });
+  describe('constructed with normalize scope option set to false', function () {
+    var strategy = new SnapchatStrategy({
+      callbackURL: '',
+      clientID: 'ABC123',
+      clientSecret: 'secret',
+      scope: ['user.display_name', 'user.bitmoji.avatar'],
+      normalizeScope: false
+    },
+      function () { });
+
+    it('should not have fully qualified scopes', function () {
+      expect(strategy._scope[0]).to.equal('user.display_name');
+      expect(strategy._scope[1]).to.equal('user.bitmoji.avatar');
+    });
+  });
 
   describe('constructed with undefined options', function() {
     it('should throw', function() {


### PR DESCRIPTION
At least with the scopes that I am trying to use, `snapchat-profile-api` and `snapchat-marketing-api`, passing them as fully qualified scopes ( e.g https://auth.snapchat.com/oauth2/api/snapchat-profile-api ) causes the API call to fail. 

This PR simply makes the scope normalization optional. 